### PR TITLE
Fixed error and added support for menus based in lists

### DIFF
--- a/dist/vanillajs-scrollspy.js
+++ b/dist/vanillajs-scrollspy.js
@@ -118,7 +118,7 @@ var VanillaScrollspy = /*#__PURE__*/function () {
         if (link.getAttribute('href') !== '#') {
           var $elem = document.querySelector(link.getAttribute('href'));
           if($elem){
-            return $elem.offsetTop <= scrollPos && $elem.offsetTop + $elem.clientHeight > scrollPos ? link.classList.add('active') : link.classList.remove('active');
+            return $elem.offsetTop <= scrollPos && $elem.offsetTop + $elem.clientHeight > scrollPos ? link.parentElement.classList.add('active') : link.parentElement.classList.remove('active');
           }
         }
       });


### PR DESCRIPTION
Fixed error generated on scroll or click when exists links with # or orphand links without targets.

If you don't agree with adding parentElement that changes to list-based menu you may not pull that commit.